### PR TITLE
Add overlay inspector logic

### DIFF
--- a/src/inspector.js
+++ b/src/inspector.js
@@ -82,6 +82,31 @@ const Inspector = ( props ) => {
 					help={ getMoveHandleHelp() }
 				/>
 			</PanelBody>
+			<PanelBody title={ __( 'Overlay', 'ib-image-comparison' ) } initialOpen={ false }>
+				<ToggleControl
+					label={ __( 'Show Overlay', 'ib-image-comparison' ) }
+					checked={ showOverlay }
+					onChange={ ( showOverlay ) =>
+						setAttributes( { showOverlay } )
+					}
+				/>
+				<ColorPickerControl
+					label={ __( 'Overlay Color', 'ib-image-comparison' ) }
+					value={ overlayColor }
+					onChange={ ( overlayColor ) =>
+						setAttributes( { overlayColor } )
+					}
+					disablePalette
+				/>
+				<ColorPickerControl
+					label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
+					value={ overlayHoverColor }
+					onChange={ ( overlayHoverColor ) =>
+						setAttributes( { overlayHoverColor } )
+					}
+					disablePalette
+				/>
+			</PanelBody>
 			<PanelBody title={ __( 'Labels', 'ib-image-comparison' ) } initialOpen={ false }>
 				<TextControl
 					label={ __( 'Before Label', 'ib-image-comparison' ) }
@@ -175,31 +200,6 @@ const Inspector = ( props ) => {
 						}
 					/>
 				</BaseControl>
-			</PanelBody>
-			<PanelBody title={ __( 'Overlay', 'ib-image-comparison' ) } initialOpen={ false }>
-				<ToggleControl
-					label={ __( 'Show Overlay', 'ib-image-comparison' ) }
-					checked={ showOverlay }
-					onChange={ ( showOverlay ) =>
-						setAttributes( { showOverlay } )
-					}
-				/>
-				<ColorPickerControl
-					label={ __( 'Overlay Color', 'ib-image-comparison' ) }
-					value={ overlayColor }
-					onChange={ ( overlayColor ) =>
-						setAttributes( { overlayColor } )
-					}
-					disablePalette
-				/>
-				<ColorPickerControl
-					label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
-					value={ overlayHoverColor }
-					onChange={ ( overlayHoverColor ) =>
-						setAttributes( { overlayHoverColor } )
-					}
-					disablePalette
-				/>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -48,7 +48,7 @@ const Inspector = ( props ) => {
 		<InspectorControls>
 			<PanelBody title={ __( 'Image Comparison Settings', 'ib-image-comparison' ) }>
 				<RangeControl
-					label={ __( 'Visibility Ratio', 'ib-image-comparison' ) }
+					label={ __( 'Visibility ratio', 'ib-image-comparison' ) }
 					value={ visibleRatio }
 					onChange={ ( visibleRatio ) =>
 						setAttributes( { visibleRatio } )
@@ -69,7 +69,7 @@ const Inspector = ( props ) => {
 					value={ orientation }
 				/>
 				<SelectControl
-					label={ __( 'Move Handle', 'ib-image-comparison' ) }
+					label={ __( 'Move handle', 'ib-image-comparison' ) }
 					options={ [
 						{ value: 'on_swipe', label: 'On Swipe' },
 						{ value: 'on_click', label: 'On Click' },
@@ -82,7 +82,7 @@ const Inspector = ( props ) => {
 					help={ getMoveHandleHelp() }
 				/>
 				<ToggleControl
-					label={ __( 'Show Overlay', 'ib-image-comparison' ) }
+					label={ __( 'Show overlay', 'ib-image-comparison' ) }
 					checked={ showOverlay }
 					onChange={ ( showOverlay ) =>
 						setAttributes( { showOverlay } )
@@ -92,7 +92,7 @@ const Inspector = ( props ) => {
 			{ showOverlay && 
 			<PanelBody title={ __( 'Overlay Colors', 'ib-image-comparison' ) } initialOpen={ false }>
 				<ColorPickerControl
-					label={ __( 'Overlay Color', 'ib-image-comparison' ) }
+					label={ __( 'Overlay color', 'ib-image-comparison' ) }
 					value={ overlayColor }
 					onChange={ ( overlayColor ) =>
 						setAttributes( { overlayColor } )
@@ -100,7 +100,7 @@ const Inspector = ( props ) => {
 					disablePalette
 				/>
 				<ColorPickerControl
-					label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
+					label={ __( 'Overlay hover color', 'ib-image-comparison' ) }
 					value={ overlayHoverColor }
 					onChange={ ( overlayHoverColor ) =>
 						setAttributes( { overlayHoverColor } )
@@ -112,7 +112,7 @@ const Inspector = ( props ) => {
 			{ showOverlay && 
 				<PanelBody title={ __( 'Labels', 'ib-image-comparison' ) } initialOpen={ false }>
 					<TextControl
-						label={ __( 'Before Label', 'ib-image-comparison' ) }
+						label={ __( 'Before label', 'ib-image-comparison' ) }
 						onChange={ ( beforeLabel ) =>
 							setAttributes( { beforeLabel } )
 						}
@@ -120,7 +120,7 @@ const Inspector = ( props ) => {
 					/>
 					
 					<TextControl
-						label={ __( 'After Label', 'ib-image-comparison' ) }
+						label={ __( 'After label', 'ib-image-comparison' ) }
 						onChange={ ( afterLabel ) =>
 							setAttributes( { afterLabel } )
 						}
@@ -160,7 +160,7 @@ const Inspector = ( props ) => {
 					<hr />
 
 					<ColorPickerControl
-						label={ __( 'Text Color', 'ib-image-comparison' ) }
+						label={ __( 'Text color', 'ib-image-comparison' ) }
 						value={ labelColor }
 						onChange={ ( labelColor ) =>
 							setAttributes( { labelColor } )
@@ -170,7 +170,7 @@ const Inspector = ( props ) => {
 					/>
 
 					<ColorPickerControl
-						label={ __( 'Background Color', 'ib-image-comparison' ) }
+						label={ __( 'Background color', 'ib-image-comparison' ) }
 						value={ labelBgColor }
 						onChange={ ( labelBgColor ) =>
 							setAttributes( { labelBgColor } )

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -90,24 +90,28 @@ const Inspector = ( props ) => {
 						setAttributes( { showOverlay } )
 					}
 				/>
-				<ColorPickerControl
-					label={ __( 'Overlay Color', 'ib-image-comparison' ) }
-					value={ overlayColor }
-					onChange={ ( overlayColor ) =>
-						setAttributes( { overlayColor } )
-					}
-					disablePalette
-				/>
-				<ColorPickerControl
-					label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
-					value={ overlayHoverColor }
-					onChange={ ( overlayHoverColor ) =>
-						setAttributes( { overlayHoverColor } )
-					}
-					disablePalette
-				/>
+				{ showOverlay && 
+					<>
+						<ColorPickerControl
+							label={ __( 'Overlay Color', 'ib-image-comparison' ) }
+							value={ overlayColor }
+							onChange={ ( overlayColor ) =>
+								setAttributes( { overlayColor } )
+							}
+							disablePalette
+						/>
+						<ColorPickerControl
+							label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
+							value={ overlayHoverColor }
+							onChange={ ( overlayHoverColor ) =>
+								setAttributes( { overlayHoverColor } )
+							}
+							disablePalette
+						/>
+					</>
+				}
 			</PanelBody>
-			{  ( showOverlay && 
+			{ showOverlay && 
 				<PanelBody title={ __( 'Labels', 'ib-image-comparison' ) } initialOpen={ false }>
 					<TextControl
 						label={ __( 'Before Label', 'ib-image-comparison' ) }
@@ -202,7 +206,7 @@ const Inspector = ( props ) => {
 						/>
 					</BaseControl>
 				</PanelBody>
-			) }
+			}
 		</InspectorControls>
 	);
 };

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -46,7 +46,7 @@ const Inspector = ( props ) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings', 'ib-image-comparison' ) }>
+			<PanelBody title={ __( 'Image Comparison Settings', 'ib-image-comparison' ) }>
 				<RangeControl
 					label={ __( 'Visibility Ratio', 'ib-image-comparison' ) }
 					value={ visibleRatio }
@@ -107,100 +107,102 @@ const Inspector = ( props ) => {
 					disablePalette
 				/>
 			</PanelBody>
-			<PanelBody title={ __( 'Labels', 'ib-image-comparison' ) } initialOpen={ false }>
-				<TextControl
-					label={ __( 'Before Label', 'ib-image-comparison' ) }
-					onChange={ ( beforeLabel ) =>
-						setAttributes( { beforeLabel } )
-					}
-					value={ beforeLabel }
-				/>
-				
-				<TextControl
-					label={ __( 'After Label', 'ib-image-comparison' ) }
-					onChange={ ( afterLabel ) =>
-						setAttributes( { afterLabel } )
-					}
-					value={ afterLabel }
-				/>
-
-				{ 'horizontal' === orientation && (
-				<SelectControl
-					label={ __( 'Position', 'ib-image-comparison' ) }
-					options={ [
-						{ label: __('Top', 'ib-image-comparison'), value: 'top' },
-						{ label: __('Middle', 'ib-image-comparison'), value: 'middle' },
-						{ label: __('Bottom', 'ib-image-comparison'), value: 'bottom' },
-					] }
-					onChange={ ( labelHPosition ) => {
-						setAttributes( { labelHPosition } );
-					} }
-					value={ labelHPosition }
-				/>
-				) }
-
-				{ 'vertical' === orientation && (
-				<SelectControl
-					label={ __( 'Position', 'ib-image-comparison' ) }
-					options={ [
-						{ label: __('Left', 'ib-image-comparison'), value: 'left' },
-						{ label: __('Center', 'ib-image-comparison'), value: 'center' },
-						{ label: __('Right', 'ib-image-comparison'), value: 'right' },
-					] }
-					onChange={ ( labelVPosition ) => {
-						setAttributes( { labelVPosition } );
-					} }
-					value={ labelVPosition }
-				/>
-				) }
-
-				<hr />
-
-				<ColorPickerControl
-					label={ __( 'Text Color', 'ib-image-comparison' ) }
-					value={ labelColor }
-					onChange={ ( labelColor ) =>
-						setAttributes( { labelColor } )
-					}
-					disableAlpha
-					disablePalette
-				/>
-
-				<ColorPickerControl
-					label={ __( 'Background Color', 'ib-image-comparison' ) }
-					value={ labelBgColor }
-					onChange={ ( labelBgColor ) =>
-						setAttributes( { labelBgColor } )
-					}
-					disablePalette
-				/>
-
-				<hr />
-
-				<RangeControl
-					label={ __( 'Border', 'ib-image-comparison' ) }
-					value={ labelBorderWidth }
-					onChange={ ( labelBorderWidth ) =>
-						setAttributes( { labelBorderWidth } )
-					}
-					min={ 0 }
-					step={ 1 }
-					max={ 10 }
-				/>
-
-				<hr />
-
-				<BaseControl
-					label={ __( 'Typography', 'ib-image-comparison' ) }
-				>
-					<FontSizePicker
-						value={ labelFontSize }
-						onChange={ ( labelFontSize ) =>
-							setAttributes( { labelFontSize } )
+			{  ( showOverlay && 
+				<PanelBody title={ __( 'Labels', 'ib-image-comparison' ) } initialOpen={ false }>
+					<TextControl
+						label={ __( 'Before Label', 'ib-image-comparison' ) }
+						onChange={ ( beforeLabel ) =>
+							setAttributes( { beforeLabel } )
 						}
+						value={ beforeLabel }
 					/>
-				</BaseControl>
-			</PanelBody>
+					
+					<TextControl
+						label={ __( 'After Label', 'ib-image-comparison' ) }
+						onChange={ ( afterLabel ) =>
+							setAttributes( { afterLabel } )
+						}
+						value={ afterLabel }
+					/>
+
+					{ 'horizontal' === orientation && (
+					<SelectControl
+						label={ __( 'Position', 'ib-image-comparison' ) }
+						options={ [
+							{ label: __('Top', 'ib-image-comparison'), value: 'top' },
+							{ label: __('Middle', 'ib-image-comparison'), value: 'middle' },
+							{ label: __('Bottom', 'ib-image-comparison'), value: 'bottom' },
+						] }
+						onChange={ ( labelHPosition ) => {
+							setAttributes( { labelHPosition } );
+						} }
+						value={ labelHPosition }
+					/>
+					) }
+
+					{ 'vertical' === orientation && (
+					<SelectControl
+						label={ __( 'Position', 'ib-image-comparison' ) }
+						options={ [
+							{ label: __('Left', 'ib-image-comparison'), value: 'left' },
+							{ label: __('Center', 'ib-image-comparison'), value: 'center' },
+							{ label: __('Right', 'ib-image-comparison'), value: 'right' },
+						] }
+						onChange={ ( labelVPosition ) => {
+							setAttributes( { labelVPosition } );
+						} }
+						value={ labelVPosition }
+					/>
+					) }
+
+					<hr />
+
+					<ColorPickerControl
+						label={ __( 'Text Color', 'ib-image-comparison' ) }
+						value={ labelColor }
+						onChange={ ( labelColor ) =>
+							setAttributes( { labelColor } )
+						}
+						disableAlpha
+						disablePalette
+					/>
+
+					<ColorPickerControl
+						label={ __( 'Background Color', 'ib-image-comparison' ) }
+						value={ labelBgColor }
+						onChange={ ( labelBgColor ) =>
+							setAttributes( { labelBgColor } )
+						}
+						disablePalette
+					/>
+
+					<hr />
+
+					<RangeControl
+						label={ __( 'Border', 'ib-image-comparison' ) }
+						value={ labelBorderWidth }
+						onChange={ ( labelBorderWidth ) =>
+							setAttributes( { labelBorderWidth } )
+						}
+						min={ 0 }
+						step={ 1 }
+						max={ 10 }
+					/>
+
+					<hr />
+
+					<BaseControl
+						label={ __( 'Typography', 'ib-image-comparison' ) }
+					>
+						<FontSizePicker
+							value={ labelFontSize }
+							onChange={ ( labelFontSize ) =>
+								setAttributes( { labelFontSize } )
+							}
+						/>
+					</BaseControl>
+				</PanelBody>
+			) }
 		</InspectorControls>
 	);
 };

--- a/src/inspector.js
+++ b/src/inspector.js
@@ -81,8 +81,6 @@ const Inspector = ( props ) => {
 					value={ moveSlider }
 					help={ getMoveHandleHelp() }
 				/>
-			</PanelBody>
-			<PanelBody title={ __( 'Overlay', 'ib-image-comparison' ) } initialOpen={ false }>
 				<ToggleControl
 					label={ __( 'Show Overlay', 'ib-image-comparison' ) }
 					checked={ showOverlay }
@@ -90,27 +88,27 @@ const Inspector = ( props ) => {
 						setAttributes( { showOverlay } )
 					}
 				/>
-				{ showOverlay && 
-					<>
-						<ColorPickerControl
-							label={ __( 'Overlay Color', 'ib-image-comparison' ) }
-							value={ overlayColor }
-							onChange={ ( overlayColor ) =>
-								setAttributes( { overlayColor } )
-							}
-							disablePalette
-						/>
-						<ColorPickerControl
-							label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
-							value={ overlayHoverColor }
-							onChange={ ( overlayHoverColor ) =>
-								setAttributes( { overlayHoverColor } )
-							}
-							disablePalette
-						/>
-					</>
-				}
 			</PanelBody>
+			{ showOverlay && 
+			<PanelBody title={ __( 'Overlay Colors', 'ib-image-comparison' ) } initialOpen={ false }>
+				<ColorPickerControl
+					label={ __( 'Overlay Color', 'ib-image-comparison' ) }
+					value={ overlayColor }
+					onChange={ ( overlayColor ) =>
+						setAttributes( { overlayColor } )
+					}
+					disablePalette
+				/>
+				<ColorPickerControl
+					label={ __( 'Overlay Hover Color', 'ib-image-comparison' ) }
+					value={ overlayHoverColor }
+					onChange={ ( overlayHoverColor ) =>
+						setAttributes( { overlayHoverColor } )
+					}
+					disablePalette
+				/>
+			</PanelBody>
+			}
 			{ showOverlay && 
 				<PanelBody title={ __( 'Labels', 'ib-image-comparison' ) } initialOpen={ false }>
 					<TextControl


### PR DESCRIPTION
The goal here is to minimize controls within the Inspector with appropriate logic to reveal relative settings based on the Overlay toggle. 

- [x] Moved the Show Overlay toggle to the main settings panel
- [x] Added logic where toggling the Show Overlay toggle will reveal the Overlay Colors and Labels panels
- [x] Updated control label casing to match Gutenberg's standards

Don't mind the "Styles" panel, that's added by my theme :)

## Screenshot:
<img width="607" alt="Screen Shot 2021-08-26 at 7 12 10 PM" src="https://user-images.githubusercontent.com/1813435/131047679-3369acaa-3236-4290-b60d-a7953bdd60e6.png">